### PR TITLE
Allow tools to run using a native config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,27 @@
+import sbt._
+
+resolvers += Resolver.sonatypeRepo("releases")
+
 name := """codacy-engine-scala-seed"""
 
 organization := "com.codacy"
 
-version := "1.5.0"
+version := "2.7.0"
 
-scalaVersion := "2.10.5"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.5", scalaVersion.value)
 
-scalacOptions := Seq("-deprecation", "-feature", "-unchecked", "-Ywarn-adapted-args", "-Xlint", "-Xfatal-warnings")
+scalacOptions := Seq("-deprecation", "-feature", "-unchecked", "-Ywarn-adapted-args", "-Xlint")
 
 resolvers += "Bintray Typesafe Repo" at "http://dl.bintray.com/typesafe/maven-releases/"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json"  % "2.3.10",
-  "org.scalatest"     %% "scalatest"  % "2.2.4" % "test",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.14"
+  "com.typesafe.play" %% "play-json" % "2.4.8",
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.14",
+  "com.codacy" %% "codacy-plugins-api" % "0.1.2" withSources(),
+  "com.github.pathikrit" %% "better-files" % "2.14.0" withSources()
 )
 
 organizationName := "Codacy"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Thu Aug 20 15:10:54 EEST 2015
 template.uuid=e17acfbb-1ff5-41f5-b8cf-2c40be6a8340
-sbt.version=0.13.8
+sbt.version=0.13.12

--- a/src/main/scala/codacy/docker/api/BackwardsCompatability.scala
+++ b/src/main/scala/codacy/docker/api/BackwardsCompatability.scala
@@ -1,0 +1,56 @@
+package codacy.docker.api
+
+import java.nio.file.Paths
+
+import codacy.docker.api.JsonApi._
+import codacy.dockerApi
+import codacy.dockerApi.{ParameterDef, ParameterName, ParameterSpec, PatternDef, PatternId, PatternSpec, Spec, ToolName}
+import play.api.libs.json._
+
+import scala.util.Try
+
+trait BackwardsCompatability {
+
+  implicit class AsTool(tool: dockerApi.Tool) extends Tool {
+    override def apply(source: Source.Directory, configuration: Option[List[Pattern.Definition]],
+                       files: Option[Set[Source.File]])(implicit specification: Tool.Specification): Try[List[Result]] = {
+      tool.apply(
+        path = Paths.get(source.path),
+        conf = configuration.map(_.map(toPatternDef)),
+        files = files.map(_.map(file => Paths.get(file.path)))
+      )(toSpec(specification)).map(_.map(toResult))
+    }
+  }
+
+  private def toResult(result: dockerApi.Result) = {
+    result match {
+      case dockerApi.Issue(filename, message, patternId, line) => Result.Issue(
+        Source.File(filename.value), Result.Message(message.value),
+        Pattern.Id(patternId.value), Source.Line(line.value)
+      )
+      case dockerApi.FileError(filename, messageOpt) =>
+        Result.FileError(Source.File(filename.value), messageOpt.map(v => ErrorMessage(v.value)))
+    }
+  }
+
+  private def toSpec(specification: Tool.Specification): Spec = {
+    Spec(ToolName(specification.name.value), specification.patterns.map(toPatternSpec))
+  }
+
+  private def toPatternSpec(specification: Pattern.Specification): PatternSpec = {
+    PatternSpec(PatternId(specification.patternId.value), specification.parameters.map(_.map(toParameterSpec)))
+  }
+
+  private def toParameterSpec(specification: Parameter.Specification): ParameterSpec = {
+    ParameterSpec(ParameterName(specification.name.value), Json.toJson(specification.default))
+  }
+
+
+  private def toParameterDef(definition: Parameter.Definition): ParameterDef = {
+    ParameterDef(ParameterName(definition.name.value), Json.toJson(definition.value))
+  }
+
+  private def toPatternDef(definition: Pattern.Definition): PatternDef = {
+    PatternDef(PatternId(definition.patternId.value), definition.parameters.map(_.map(toParameterDef)))
+  }
+}

--- a/src/main/scala/codacy/docker/api/JsonApi.scala
+++ b/src/main/scala/codacy/docker/api/JsonApi.scala
@@ -1,0 +1,116 @@
+package codacy.docker.api
+
+import play.api.libs.json._
+import scala.language.implicitConversions
+
+private[api] case class ParamValue(value:JsValue) extends AnyVal with Parameter.Value
+
+trait JsonApi {
+
+  def enumWrites[E <: Enumeration#Value]: Writes[E] = Writes((e: E) => Json.toJson(e.toString))
+
+  def enumReads[E <: Enumeration](e: E): Reads[e.Value] = {
+    Reads.StringReads.flatMap { case value => Reads((_: JsValue) =>
+      e.values.collectFirst { case enumValue if enumValue.toString == value =>
+        JsSuccess(enumValue)
+      }.getOrElse(JsError(s"Invalid enumeration value $value"))
+    )
+    }
+  }
+
+  implicit def paramValueToJsValue(paramValue:Parameter.Value): JsValue = {
+    paramValue match {
+      case ParamValue(v) => v
+      case _ => JsNull
+    }
+  }
+
+  implicit lazy val parameterValueFormat: Format[Parameter.Value] = Format(
+    implicitly[Reads[JsValue]].map( Parameter.Value ),
+    Writes( paramValueToJsValue )
+  )
+
+  implicit lazy val resultLevelFormat = Format(
+    enumReads(Result.Level),
+    enumWrites[Result.Level]
+  )
+  implicit lazy val patternCategoryFormat = Format(
+    enumReads(Pattern.Category),
+    enumWrites[Pattern.Category]
+  )
+
+  implicit lazy val patternIdFormat = Format(Reads.StringReads.map(Pattern.Id),
+    Writes((v: Pattern.Id) => Json.toJson(v.value))) //Json.format[Pattern.Id]
+
+  implicit lazy val errorMessageFormat = Format(Reads.StringReads.map(ErrorMessage),
+    Writes((v: ErrorMessage) => Json.toJson(v.value))) //Json.format[ErrorMessage]
+
+  implicit lazy val resultMessageFormat = Format(Reads.StringReads.map(Result.Message),
+    Writes((v: Result.Message) => Json.toJson(v.value))) //Json.format[Result.Message]
+
+  implicit lazy val resultLineFormat = Format(Reads.IntReads.map(Source.Line),
+    Writes((v: Source.Line) => Json.toJson(v.value))) //Json.format[Result.Line]
+
+  implicit lazy val parameterNameFormat = Format(Reads.StringReads.map(Parameter.Name),
+    Writes((v: Parameter.Name) => Json.toJson(v.value))) //Json.format[Parameter.Name]
+
+  implicit lazy val toolNameFormat = Format(Reads.StringReads.map(Tool.Name),
+    Writes((v: Tool.Name) => Json.toJson(v.value))) //Json.format[Tool.Name]
+
+  implicit lazy val sourceFileFormat = Format(Reads.StringReads.map(Source.File),
+    Writes((v: Source.File) => Json.toJson(v.path))) //Json.format[Source.File]
+
+  implicit lazy val parameterSpecificationFormat = Json.format[Parameter.Specification]
+  implicit lazy val parameterDefinitionFormat = Json.format[Parameter.Definition]
+  implicit lazy val patternDefinitionFormat = Json.format[Pattern.Definition]
+  implicit lazy val patternSpecificationFormat = Json.format[Pattern.Specification]
+  implicit lazy val toolConfigurationFormat = Json.format[Tool.Configuration]
+  implicit lazy val specificationFormat = Json.format[Tool.Specification]
+  implicit lazy val configurationFormat = Json.format[Configuration]
+
+  implicit lazy val resultWrites: Writes[Result] = Writes[Result]((_: Result) match {
+    case r: Result.Issue => Json.writes[Result.Issue].writes(r)
+    case e: Result.FileError => Json.writes[Result.FileError].writes(e)
+  })
+
+  implicit lazy val resultReads: Reads[Result] = {
+    //check issue then error then oldResult
+    issueFormat.map(identity[Result]) orElse
+      errorFormat.map(identity[Result]) orElse
+      oldResultReads
+  }
+
+  //old formats still out there...
+  private[this] implicit lazy val errorFormat = Json.format[Result.FileError]
+  private[this] implicit lazy val issueFormat = Json.format[Result.Issue]
+
+  private[this] sealed trait ToolResult
+
+  private[this] case class Issue(filename: String, message: String, patternId: String, line: Int) extends ToolResult
+
+  private[this] case class FileError(filename: String, message: Option[String]) extends ToolResult
+
+  private[this] lazy val oldResultReads: Reads[Result] = {
+
+    lazy val IssueReadsName = Issue.getClass.getSimpleName
+    lazy val issueReads = Json.reads[Issue].map(identity[ToolResult])
+
+    lazy val ErrorReadsName = FileError.getClass.getSimpleName
+    lazy val errorReads = Json.reads[FileError].map(identity[ToolResult])
+
+    Reads { (result: JsValue) =>
+      (result \ "type").validate[String].flatMap {
+        case IssueReadsName => issueReads.reads(result)
+        case ErrorReadsName => errorReads.reads(result)
+        case tpe => JsError(s"not a valid result type $tpe")
+      }
+    }.orElse(issueReads).orElse(errorReads).map {
+      case Issue(filename, message, patternId, line) =>
+        Result.Issue(Source.File(filename), Result.Message(message), Pattern.Id(patternId), Source.Line(line))
+      case FileError(filename, messageOpt) =>
+        Result.FileError(Source.File(filename), messageOpt.map(ErrorMessage))
+    }
+  }
+}
+
+object JsonApi extends JsonApi

--- a/src/main/scala/codacy/docker/api/package.scala
+++ b/src/main/scala/codacy/docker/api/package.scala
@@ -1,0 +1,14 @@
+package codacy.docker
+
+import play.api.libs.json.{JsNull, JsString, JsValue, Json}
+
+import scala.util.Try
+
+package object api extends JsonApi{
+
+  implicit class ParameterExtensions(param:Parameter.type){
+    def Value(jsValue:JsValue):Parameter.Value = ParamValue(jsValue)
+    def Value(raw:String):Parameter.Value = Value(Try(Json.parse(raw)).getOrElse(JsString(raw)))
+  }
+
+}

--- a/src/main/scala/codacy/dockerApi/DockerEngine.scala
+++ b/src/main/scala/codacy/dockerApi/DockerEngine.scala
@@ -1,6 +1,9 @@
 package codacy.dockerApi
 
+import java.nio.file.Paths
+
 import akka.actor.ActorSystem
+import codacy.docker.api.{Source, Result => NewResult}
 import codacy.dockerApi.DockerEnvironment._
 import play.api.libs.json.{Json, Writes}
 
@@ -8,7 +11,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-abstract class DockerEngine(Tool: Tool) {
+abstract class DockerEngine(Tool: codacy.docker.api.Tool) {
 
   lazy val sys = ActorSystem("timeoutSystem")
 
@@ -32,49 +35,62 @@ abstract class DockerEngine(Tool: Tool) {
   }
 
   def main(args: Array[String]): Unit = {
+    log("starting timeout")
     initTimeout(timeout)
 
-    spec.flatMap { implicit spec =>
-      config.flatMap { case maybeConfig =>
-        //search for our config
-        val maybePatterns = maybeConfig.flatMap(_.tools.collectFirst { case config if config.name == spec.name =>
-          val allPatternIds = spec.patterns.map(_.patternId)
-          config.patterns.filter { case pattern => allPatternIds.contains(pattern.patternId) }
-        })
-        val maybeFiles = maybeConfig.flatMap(_.files.map(_.map { case path =>
-          sourcePath.resolve(path.value)
-        }))
+    for {
+      spec <- specification
+      configOpt <- configuration
+    } yield {
 
-        log("tool started")
-        try {
-          Tool.apply(
-            path = sourcePath,
-            conf = maybePatterns,
-            files = maybeFiles
-          )
-        } catch {
-          // We need to catch Throwable here to avoid JVM crashes
-          // Crashes can lead to docker not exiting properly
-          case e: Throwable =>
-            Failure(e)
-        }
+      val patternsOpt = for {
+        config <- configOpt
+        toolCfg <- config.tools.find(_.name == spec.name)
+        patterns <- toolCfg.patterns
+      } yield {
+        lazy val existingPatternIds = spec.patterns.map(_.patternId)
+        patterns.filter(pattern => existingPatternIds contains pattern.patternId)
       }
-    } match {
-      case Success(results) =>
-        log("receiving results")
-        results.foreach {
-          case issue: Issue =>
-            val relativeIssue = issue.copy(filename = SourcePath(relativize(issue.filename.value)))
-            logResult(relativeIssue)
-          case error: FileError =>
-            val relativeIssue = error.copy(filename = SourcePath(relativize(error.filename.value)))
-            logResult(relativeIssue)
-        }
-        log("tool finished")
-        System.exit(0)
-      case Failure(error) =>
-        error.printStackTrace(Console.err)
-        Runtime.getRuntime.halt(1)
+
+      val filesOpt = for {
+        config <- configOpt
+        files <- config.files
+      } yield {
+        //TODO: i see a problem with the .toString here, also convert it to better-files ops please!
+        files.map { case file => file.copy(path = sourcePath.path.resolve(Paths.get(file.path)).toString) }
+      }
+
+      log("tool started")
+      // We need to catch Throwable here to avoid JVM crashes
+      // Crashes can lead to docker not exiting properly
+      val res = (try {
+        Tool.apply(
+          source = Source.Directory(sourcePath.toString()),
+          configuration = patternsOpt,
+          files = filesOpt
+        )(spec)
+      } catch {
+        case t: Throwable =>
+          Failure(t)
+      })
+
+      res match {
+        case Success(results) =>
+          log("receiving results")
+          results.foreach {
+            case issue@NewResult.Issue(file, _, _, _) =>
+              val relativeIssue = issue.copy(file = Source.File(relativize(issue.file.path)))
+              logResult(relativeIssue)
+            case error@NewResult.FileError(filename, _) =>
+              val relativeIssue = error.copy(file = Source.File(relativize(error.file.path)))
+              logResult(relativeIssue)
+          }
+          log("tool finished")
+          System.exit(0)
+        case Failure(error) =>
+          error.printStackTrace(Console.err)
+          Runtime.getRuntime.halt(1)
+      }
     }
   }
 

--- a/src/main/scala/codacy/dockerApi/DockerEnvironment.scala
+++ b/src/main/scala/codacy/dockerApi/DockerEnvironment.scala
@@ -2,6 +2,8 @@ package codacy.dockerApi
 
 import java.nio.file.{Files, Paths}
 
+import better.files._
+import codacy.docker.api.{Configuration, Tool => NewTool}
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsError, JsPath, Json}
 
@@ -9,7 +11,29 @@ import scala.util.{Failure, Success, Try}
 
 object DockerEnvironment {
 
-  def config(implicit spec: Spec): Try[Option[FullConfig]] = Try(Files.readAllBytes(configFilePath)).transform(
+  lazy val configuration: Try[Option[Configuration]] = {
+    if (configFilePath.isRegularFile) {
+      for {
+        content <- Try(configFilePath.byteArray)
+        json <- Try(Json.parse(content))
+        cfg <- json.validate[Configuration].asTry
+      } yield Some(cfg)
+    } else {
+      Success(Option.empty[Configuration])
+    }
+  }
+
+  lazy val specification: Try[NewTool.Specification] = {
+    for {
+      content <- Try(specificationPath.byteArray)
+      json <- Try(Json.parse(content))
+      spec <- json.validate[NewTool.Specification].asTry
+    } yield spec
+  }
+
+  //TODO: check why we returned an empty config on json parse error before
+  @deprecated("use configuration instead", "2.7.0")
+  def config(implicit spec: Spec): Try[Option[FullConfig]] = Try(Files.readAllBytes(configFilePath.path)).transform(
     raw => Try(Json.parse(raw)).flatMap(
       _.validate[FullConfig].fold(
         asFailure,
@@ -18,6 +42,7 @@ object DockerEnvironment {
     _ => Success(Option.empty[FullConfig])
   )
 
+  @deprecated("use specification instead", "2.7.0")
   lazy val spec: Try[Spec] = {
     Try(
       Files.readAllBytes(Paths.get("/docs/patterns.json"))
@@ -30,9 +55,9 @@ object DockerEnvironment {
   }
 
   private[this] def asFailure(error: Seq[(JsPath, Seq[ValidationError])]) =
-    Failure(new Throwable(Json.stringify(JsError.toFlatJson(error.toList))))
+    Failure(new Throwable(Json.stringify(JsError.toJson(error.toList))))
 
-  private[this] lazy val configFilePath = sourcePath.resolve(".codacy.json")
-
-  lazy val sourcePath = Paths.get("/src")
+  private[dockerApi] lazy val configFilePath = sourcePath / ".codacy.json"
+  private[dockerApi] lazy val sourcePath = File("/src")
+  private[dockerApi] lazy val specificationPath = File("/docs/patterns.json")
 }

--- a/src/main/scala/codacy/dockerApi/package.scala
+++ b/src/main/scala/codacy/dockerApi/package.scala
@@ -2,95 +2,121 @@ package codacy
 
 import java.nio.file.Path
 
+import codacy.docker.api.{BackwardsCompatability, JsonApi}
 import play.api.libs.json.{JsValue, Reads, Writes, _}
 
 import scala.language.reflectiveCalls
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 package dockerApi {
 
-abstract class Formats[W <: AnyVal {val value : B}, B](apply_ : (B => W)) extends (B => W) {
-  self =>
+  abstract class Formats[W <: AnyVal {val value : B}, B](apply_ : (B => W)) extends (B => W) {
+    self =>
 
-  implicit def writes(implicit writes: Writes[B]): Writes[W] = Writes(
-    (_: W).value match { case value: B@unchecked => writes.writes(value) }
-  )
+    implicit def writes(implicit writes: Writes[B]): Writes[W] = Writes(
+      (_: W).value match { case value: B@unchecked => writes.writes(value) }
+    )
 
-  implicit def reads(implicit reads: Reads[B]): Reads[W] = reads.map(self.apply)
+    implicit def reads(implicit reads: Reads[B]): Reads[W] = reads.map(self.apply)
 
-  override def apply(v1: B): W = apply_(v1)
+    override def apply(v1: B): W = apply_(v1)
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  trait Tool {
+    def apply(path: Path, conf: Option[List[PatternDef]], files: Option[Set[Path]])(implicit spec: Spec): Try[List[Result]]
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class PatternId(val value: String) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class SourcePath(val value: String) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class ResultMessage(val value: String) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class ResultLine(val value: Int) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class ToolName(val value: String) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class ErrorMessage(val value: String) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final class ParameterName(val value: String) extends AnyVal {
+    override def toString = value.toString
+  }
+
+  object PatternId extends Formats[PatternId, String](new PatternId(_))
+
+  object SourcePath extends Formats[SourcePath, String](new SourcePath(_))
+
+  object ResultMessage extends Formats[ResultMessage, String](new ResultMessage(_))
+
+  object ResultLine extends Formats[ResultLine, Int](new ResultLine(_))
+
+  object ToolName extends Formats[ToolName, String](new ToolName(_))
+
+  object ErrorMessage extends Formats[ErrorMessage, String](new ErrorMessage(_))
+
+  object ParameterName extends Formats[ParameterName, String](new ParameterName(_))
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class ParameterDef(name: ParameterName, value: JsValue)
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class PatternDef(patternId: PatternId, parameters: Option[Set[ParameterDef]])
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class ToolConfig(name: ToolName, patterns: List[PatternDef])
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class FullConfig(tools: Set[ToolConfig], files: Option[Set[SourcePath]])
+
+  //there are other fields like name and description but i don't care about them inside the tool
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class ParameterSpec(name: ParameterName, default: JsValue)
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class PatternSpec(patternId: PatternId, parameters: Option[Set[ParameterSpec]])
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  case class Spec(name: ToolName, patterns: Set[PatternSpec])
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  sealed trait Result
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final case class Issue(filename: SourcePath, message: ResultMessage, patternId: PatternId, line: ResultLine) extends Result
+
+  @deprecated("use the new codacy.docker.api types instead", "2.7.0")
+  final case class FileError(filename: SourcePath, message: Option[ErrorMessage]) extends Result
+
 }
 
-trait Tool {
-  def apply(path: Path, conf: Option[List[PatternDef]], files: Option[Set[Path]])(implicit spec: Spec): Try[List[Result]]
-}
+package object dockerApi extends BackwardsCompatability with JsonApi {
 
-final class PatternId(val value: String) extends AnyVal {
-  override def toString = value.toString
-}
-
-final class SourcePath(val value: String) extends AnyVal {
-  override def toString = value.toString
-}
-
-final class ResultMessage(val value: String) extends AnyVal {
-  override def toString = value.toString
-}
-
-final class ResultLine(val value: Int) extends AnyVal {
-  override def toString = value.toString
-}
-
-final class ToolName(val value: String) extends AnyVal {
-  override def toString = value.toString
-}
-
-final class ErrorMessage(val value: String) extends AnyVal {
-  override def toString = value.toString
-}
-
-final class ParameterName(val value: String) extends AnyVal {
-  override def toString = value.toString
-}
-
-object PatternId extends Formats[PatternId, String](new PatternId(_))
-
-object SourcePath extends Formats[SourcePath, String](new SourcePath(_))
-
-object ResultMessage extends Formats[ResultMessage, String](new ResultMessage(_))
-
-object ResultLine extends Formats[ResultLine, Int](new ResultLine(_))
-
-object ToolName extends Formats[ToolName, String](new ToolName(_))
-
-object ErrorMessage extends Formats[ErrorMessage, String](new ErrorMessage(_))
-
-object ParameterName extends Formats[ParameterName, String](new ParameterName(_))
-
-case class ParameterDef(name: ParameterName, value: JsValue)
-
-case class PatternDef(patternId: PatternId, parameters: Option[Set[ParameterDef]])
-
-case class ToolConfig(name: ToolName, patterns: List[PatternDef])
-
-case class FullConfig(tools: Set[ToolConfig], files: Option[Set[SourcePath]])
-
-//there are other fields like name and description but i don't care about them inside the tool
-case class ParameterSpec(name: ParameterName, default: JsValue)
-
-case class PatternSpec(patternId: PatternId, parameters: Option[Set[ParameterSpec]])
-
-case class Spec(name: ToolName, patterns: Set[PatternSpec])
-
-sealed trait Result
-
-final case class Issue(filename: SourcePath, message: ResultMessage, patternId: PatternId, line: ResultLine) extends Result
-
-final case class FileError(filename: SourcePath, message: Option[ErrorMessage]) extends Result
-
-}
-
-package object dockerApi {
+  implicit class ResultExtension[A](val result: JsResult[A]) extends AnyVal {
+    def asTry = result.fold(
+      error => Failure(new Throwable(Json.stringify(JsError.toJson(error)))),
+      Success.apply
+    )
+  }
 
   implicit def toValue[A] = (a: AnyVal {def value: A}) => a.value
 

--- a/src/test/scala/codacy/dockerApi/utils/CommandRunnerTest.scala
+++ b/src/test/scala/codacy/dockerApi/utils/CommandRunnerTest.scala
@@ -1,7 +1,7 @@
 package codacy.dockerApi.utils
 
-import org.scalatest._
 import org.scalatest.EitherValues._
+import org.scalatest._
 
 import scala.collection.mutable.ArrayBuffer
 


### PR DESCRIPTION
notes:
I had to remove the "-Xfatal-warnings" flag due to deprecation warnings. I know there is a parameter for excluding the deprecation warning but it doesn't work in scala 2.10 and we are cross-publishing.

the seed now uses the shared interface that the plugins-tests and our internal logic uses.