### PR TITLE
bump: Bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@0.3.14
+  codacy: codacy/base@2.0.1
 
 workflows:
   version: 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @lolgab @ljmf00 @andreaTP @rtfpessoa @bmbferreira @DReigada @pedrocodacy
-
-*.yml @h314to @paulopontesm
-
+* @codacy/toss

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val scala211 = "2.11.12"
 val scala212 = "2.12.10"
 val scala213 = "2.13.1"
 
-val specs2Version = "4.7.1"
+val specs2Version = "4.8.3"
 
 ThisBuild / organization := "com.codacy"
 ThisBuild / scalaVersion := scala212
@@ -11,7 +11,7 @@ ThisBuild / crossScalaVersions := Seq(scala211, scala212, scala213)
 name := "codacy-engine-scala-seed"
 
 libraryDependencies ++= Seq(("com.typesafe.play" %% "play-json" % "2.7.4").withSources(),
-                            ("com.codacy" %% "codacy-plugins-api" % "3.0.80").withSources(),
+                            ("com.codacy" %% "codacy-plugins-api" % "3.4.0").withSources(),
                             ("com.github.pathikrit" %% "better-files" % "3.8.0").withSources(),
                             "org.specs2" %% "specs2-core" % specs2Version % Test,
                             "org.specs2" %% "specs2-mock" % specs2Version % Test)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.jcenterRepo
-addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "17.0.4")
+addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "17.1.5")

--- a/src/main/scala/com/codacy/plugins/api/package.scala
+++ b/src/main/scala/com/codacy/plugins/api/package.scala
@@ -1,11 +1,11 @@
 package com.codacy.plugins
 
+import scala.language.implicitConversions
+import scala.util.Try
+import play.api.libs.json.{JsResult, _}
 import com.codacy.plugins.api.languages.{Language, Languages}
 import com.codacy.plugins.api.results.{Parameter, Pattern, Result, Tool}
-import play.api.libs.json.{JsResult, _}
-import scala.language.implicitConversions
-
-import scala.util.Try
+import com.codacy.plugins.api.results.Pattern.{Category, Subcategory}
 
 package object api {
 
@@ -128,7 +128,50 @@ package object api {
   implicit lazy val parameterSpecificationFormat: Format[Parameter.Specification] = Json.format[Parameter.Specification]
   implicit lazy val parameterDefinitionFormat: Format[Parameter.Definition] = Json.format[Parameter.Definition]
   implicit lazy val patternDefinitionFormat: Format[Pattern.Definition] = Json.format[Pattern.Definition]
-  implicit lazy val patternSpecificationFormat: Format[Pattern.Specification] = Json.format[Pattern.Specification]
+
+  /**
+    * Defines how a Pattern.Subcategory object should be written/read to/from json.
+    */
+  implicit lazy val patternSubCategoryFormat: Format[Pattern.Subcategory.Value] =
+    Format(enumReads(Pattern.Subcategory), enumWrites[Pattern.Subcategory])
+
+  /**
+    * Defines how a [[Pattern.Specification]] object should be written to json.
+    */
+  private val patternSpecificationWrites: Writes[Pattern.Specification] = new Writes[Pattern.Specification] {
+    override def writes(spec: Pattern.Specification): JsValue =
+      Json.obj("patternId" -> Json.toJson(spec.patternId),
+               "level" -> Json.toJson(spec.level),
+               "category" -> Json.toJson(spec.category),
+               "subcategory" -> Json.toJson(spec.subcategory),
+               "parameters" -> Json.toJson(spec.parameters),
+               "languages" -> Json.toJson(spec.languages))
+  }
+
+  /**
+    * Defines how a [[Pattern.Specification]] object should be read from json.
+    */
+  private val patternSpecificationReads: Reads[Pattern.Specification] = new Reads[Pattern.Specification] {
+    override def reads(json: JsValue): JsResult[Pattern.Specification] = {
+      JsSuccess(
+        Pattern.Specification((json \ "patternId").as[Pattern.Id],
+                              (json \ "level").as[Result.Level],
+                              (json \ "category").as[Category],
+                              (json \ "subcategory").asOpt[Subcategory],
+                              (json \ "parameters").asOpt[Set[Parameter.Specification]],
+                              (json \ "languages").asOpt[Set[Language]])
+      )
+    }
+  }
+
+  /**
+    * Aggregates the Reads and Writes objects for Pattern.Specification.
+    * @note This seems to be required since Json.format[Pattern.Specification]
+    *       doesn't seem to be able to serialize/deserialize automatically.
+    */
+  implicit lazy val patternSpecificationFormat: Format[Pattern.Specification] =
+    Format(patternSpecificationReads, patternSpecificationWrites)
+
   implicit lazy val toolConfigurationFormat: Format[Tool.Configuration] = Json.format[Tool.Configuration]
 
   implicit lazy val specificationFormat: Format[Tool.Specification] =

--- a/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
@@ -1,16 +1,15 @@
 package com.codacy.tools.scala.seed
 
 import java.nio.file.{Path, Paths}
-
+import scala.concurrent.duration._
+import scala.util.{Success, Try}
 import better.files._
+import play.api.libs.json.Json
 import com.codacy.plugins.api._
 import com.codacy.plugins.api.results.Tool
-import com.codacy.tools.scala.seed.traits.JsResultOps._
-import play.api.libs.json.Json
 
-import scala.concurrent.duration.{Duration, FiniteDuration, _}
-import scala.util.{Success, Try}
-import java.util.concurrent.TimeUnit
+import com.codacy.tools.scala.seed.traits.JsResultOps._
+import com.codacy.tools.scala.seed.utils.TimeoutHelper
 
 class DockerEnvironment(variables: Map[String, String] = sys.env) {
 
@@ -21,7 +20,7 @@ class DockerEnvironment(variables: Map[String, String] = sys.env) {
   val defaultTimeout: FiniteDuration =
     variables
       .get("TIMEOUT_SECONDS")
-      .flatMap(timeoutStrValue => Try(FiniteDuration(timeoutStrValue.toLong, TimeUnit.SECONDS)).toOption)
+      .flatMap(TimeoutHelper.parseTimeout)
       .getOrElse(15.minutes)
 
   val debug: Boolean =

--- a/src/main/scala/com/codacy/tools/scala/seed/utils/TimeoutHelper.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/utils/TimeoutHelper.scala
@@ -1,0 +1,11 @@
+package com.codacy.tools.scala.seed.utils
+
+import scala.util.Try
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+object TimeoutHelper {
+
+  def parseTimeout(timeoutSeconds: String): Option[FiniteDuration] =
+    Try(FiniteDuration(timeoutSeconds.toLong, TimeUnit.SECONDS)).toOption
+}

--- a/src/test/scala/com/codacy/tools/scala/seed/utils/TimeoutHelperTest.scala
+++ b/src/test/scala/com/codacy/tools/scala/seed/utils/TimeoutHelperTest.scala
@@ -1,0 +1,21 @@
+package com.codacy.tools.scala.seed.utils
+
+import scala.concurrent.duration._
+import org.specs2.mutable.Specification
+
+class TimeoutHelperTest extends Specification {
+
+  "TimeoutHelper" >> {
+    "parseTimeout" >> {
+      "parse seconds integers" >> {
+        val result = TimeoutHelper.parseTimeout("60")
+        result must beEqualTo(Some(60.seconds))
+      }
+      "return None in case of strings that are not integers" >> {
+        TimeoutHelper.parseTimeout("") must beEqualTo(None)
+
+        TimeoutHelper.parseTimeout("foo") must beEqualTo(None)
+      }
+    }
+  }
+}

--- a/src/test/scala/com/codacy/tools/scala/seed/utils/ToolHelperTest.scala
+++ b/src/test/scala/com/codacy/tools/scala/seed/utils/ToolHelperTest.scala
@@ -2,7 +2,7 @@ package com.codacy.tools.scala.seed.utils
 
 import com.codacy.plugins.api._
 import com.codacy.plugins.api.results.{Parameter, Pattern, Result, Tool}
-import com.codacy.tools.scala.seed.utils.ToolHelper._
+import ToolHelper._
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsNumber, JsString}
 
@@ -14,10 +14,11 @@ class ToolHelperTest extends Specification {
   val patternSpecification1 = Pattern.Specification(Pattern.Id("id1"),
                                                     Result.Level.Warn,
                                                     Pattern.Category.CodeStyle,
+                                                    None,
                                                     Some(Set(paramSpec1, paramSpec2)))
 
   val patternSpecification2 =
-    Pattern.Specification(Pattern.Id("id2"), Result.Level.Warn, Pattern.Category.CodeStyle, None)
+    Pattern.Specification(Pattern.Id("id2"), Result.Level.Warn, Pattern.Category.CodeStyle, None, None)
   val patternsSpec = Set(patternSpecification1, patternSpecification2)
 
   val paramDef1 = Parameter.Definition(Parameter.Name("param1"), Parameter.Value(JsNumber(33)))


### PR DESCRIPTION
- Bump specs2 to 4.8.3
- Bump codacy-plugins-api to 3.4.0
- Add support for subcategories
- Bump codacy-sbt-plugin to 17.1.5
- Bump sbt to 1.3.6
- Refactor timeout parsing to a separate module
- Add test for TimeoutHelper