### PR TITLE
breaking: Make timeout optional

### DIFF
--- a/src/main/scala/com/codacy/tools/scala/seed/DockerEngine.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/DockerEngine.scala
@@ -15,7 +15,12 @@ abstract class DockerEngine(tool: Tool, env: DockerEnvironment = new DockerEnvir
     with Haltable {
 
   def main(args: Array[String]): Unit = {
-    initTimeout(env.timeout)
+    env.timeout match {
+      case Some(timeout) =>
+        initTimeout(timeout)
+      case _ =>
+        printer.debug("There is no internal timeout set")
+    }
 
     val result = (for {
       specification <- env.specification

--- a/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
@@ -13,11 +13,11 @@ import com.codacy.tools.scala.seed.utils.TimeoutHelper
 
 class DockerEnvironment(variables: Map[String, String] = sys.env) {
 
-  val defaultRootFile: Path = Paths.get("/src")
-  val defaultConfigFile: Path = Paths.get("/.codacyrc")
-  val defaultSpecificationFile: Path = Paths.get("/docs/patterns.json")
+  val rootFile: Path = Paths.get("/src")
+  val configFile: File = Paths.get("/.codacyrc")
+  val specificationFile: File = Paths.get("/docs/patterns.json")
 
-  val defaultTimeout: FiniteDuration =
+  val timeout: FiniteDuration =
     variables
       .get("TIMEOUT_SECONDS")
       .flatMap(TimeoutHelper.parseTimeout)
@@ -26,7 +26,7 @@ class DockerEnvironment(variables: Map[String, String] = sys.env) {
   val debug: Boolean =
     variables.get("DEBUG").flatMap(debugStrValue => Try(debugStrValue.toBoolean).toOption).getOrElse(false)
 
-  def configurations(configFile: File = defaultConfigFile): Try[Option[Tool.CodacyConfiguration]] = {
+  def configurations: Try[Option[Tool.CodacyConfiguration]] = {
     if (configFile.exists) {
       for {
         content <- Try(configFile.byteArray)
@@ -38,9 +38,9 @@ class DockerEnvironment(variables: Map[String, String] = sys.env) {
     }
   }
 
-  def specification(specificationPath: File = defaultSpecificationFile): Try[Tool.Specification] = {
+  def specification: Try[Tool.Specification] = {
     for {
-      content <- Try(specificationPath.byteArray)
+      content <- Try(specificationFile.byteArray)
       json <- Try(Json.parse(content))
       spec <- json.validate[Tool.Specification].asTry
     } yield spec

--- a/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
@@ -17,11 +17,10 @@ class DockerEnvironment(variables: Map[String, String] = sys.env) {
   val configFile: File = Paths.get("/.codacyrc")
   val specificationFile: File = Paths.get("/docs/patterns.json")
 
-  val timeout: FiniteDuration =
+  val timeout: Option[FiniteDuration] =
     variables
       .get("TIMEOUT_SECONDS")
       .flatMap(TimeoutHelper.parseTimeout)
-      .getOrElse(15.minutes)
 
   val debug: Boolean =
     variables.get("DEBUG").flatMap(debugStrValue => Try(debugStrValue.toBoolean).toOption).getOrElse(false)

--- a/src/main/scala/com/codacy/tools/scala/seed/Printer.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/Printer.scala
@@ -12,7 +12,7 @@ class Printer(infoStream: PrintStream = Console.out,
               errStream: PrintStream = Console.err,
               dockerEnvironment: DockerEnvironment = new DockerEnvironment()) {
 
-  def info(message: String, error: Option[Throwable] = Option.empty[Throwable]): Unit = {
+  def debug(message: String, error: Option[Throwable] = Option.empty[Throwable]): Unit = {
     if (dockerEnvironment.debug) {
       infoStream.println(message)
       error.foreach(_.printStackTrace(infoStream))

--- a/src/test/scala/com/codacy/tools/scala/seed/PrinterSpecs.scala
+++ b/src/test/scala/com/codacy/tools/scala/seed/PrinterSpecs.scala
@@ -19,7 +19,7 @@ class PrinterSpecs extends Specification {
       val printer = new Printer(printStream)
       val dockerMetricsEnvironment = new DockerEnvironment(Map.empty)
       val fileName = "a.scala"
-      val sourcePath = dockerMetricsEnvironment.defaultRootFile
+      val sourcePath = dockerMetricsEnvironment.rootFile
       val result =
         Issue(Source.File("a.scala"), Result.Message("Found issue"), Pattern.Id("pattern-id"), Source.Line(1))
 


### PR DESCRIPTION
When not passing any TIMEOUT_SECONDS the tool would default to 15 minutes before this change. Now, the tool will only time out if configured to do so.

Regarding the refactor:

The removed machinery is not used as you can see doing a search like:

```
https://github.com/search?q=org%3Acodacy+%22DockerEngine%22&type=Code
```

If you check, all the parameterization was done based on something that the DockerEngine was already being built with with all the "dockerEnvironment.", which does not make much sense

