### PR TITLE
clean: Stop using better-files and use java.nio directly :feature:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,7 @@ name := "codacy-engine-scala-seed"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.9.2",
-  "com.codacy" %% "codacy-plugins-api" % "5.3.2",
-  "com.github.pathikrit" %% "better-files" % "3.8.0"
+  "com.codacy" %% "codacy-plugins-api" % "5.3.2"
 ) ++ Seq("specs2-core", "specs2-mock").map("org.specs2" %% _ % specs2Version % Test)
 
 scalacOptions := Seq()

--- a/src/main/scala/com/codacy/tools/scala/seed/DockerEngine.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/DockerEngine.scala
@@ -23,8 +23,8 @@ abstract class DockerEngine(tool: Tool, dockerEnvironment: DockerEnvironment = n
     initTimeout(timeout)
 
     val result = (for {
-      specification <- dockerEnvironment.specification(specificationFile)
-      configurations <- dockerEnvironment.configurations(configFile)
+      specification <- dockerEnvironment.specification(specificationFile.toFile)
+      configurations <- dockerEnvironment.configurations(configFile.toFile)
     } yield {
       val toolConfiguration = getToolConfiguration(specification, configurations)
       val files = getFiles(configurations)

--- a/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala
@@ -1,9 +1,9 @@
 package com.codacy.tools.scala.seed
 
-import java.nio.file.{Path, Paths}
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
-import better.files._
 import play.api.libs.json.Json
 import com.codacy.plugins.api._
 import com.codacy.plugins.api.results.Tool
@@ -26,10 +26,10 @@ class DockerEnvironment(variables: Map[String, String] = sys.env) {
   val debug: Boolean =
     variables.get("DEBUG").flatMap(debugStrValue => Try(debugStrValue.toBoolean).toOption).getOrElse(false)
 
-  def configurations(configFile: File = defaultConfigFile): Try[Option[Tool.CodacyConfiguration]] = {
+  def configurations(configFile: File = defaultConfigFile.toFile): Try[Option[Tool.CodacyConfiguration]] = {
     if (configFile.exists) {
       for {
-        content <- Try(configFile.byteArray)
+        content <- Try(Files.readAllBytes(configFile.toPath))
         json <- Try(Json.parse(content))
         cfg <- json.validate[Tool.CodacyConfiguration].asTry
       } yield Some(cfg)
@@ -38,9 +38,9 @@ class DockerEnvironment(variables: Map[String, String] = sys.env) {
     }
   }
 
-  def specification(specificationPath: File = defaultSpecificationFile): Try[Tool.Specification] = {
+  def specification(specificationPath: File = defaultSpecificationFile.toFile): Try[Tool.Specification] = {
     for {
-      content <- Try(specificationPath.byteArray)
+      content <- Try(Files.readAllBytes(specificationPath.toPath))
       json <- Try(Json.parse(content))
       spec <- json.validate[Tool.Specification].asTry
     } yield spec

--- a/src/main/scala/com/codacy/tools/scala/seed/utils/FileHelper.scala
+++ b/src/main/scala/com/codacy/tools/scala/seed/utils/FileHelper.scala
@@ -2,8 +2,8 @@ package com.codacy.tools.scala.seed.utils
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Path, StandardOpenOption}
-
-import better.files.File
+import java.nio.file.Files
+import scala.collection.JavaConverters._
 
 object FileHelper {
 
@@ -11,9 +11,9 @@ object FileHelper {
     * Create temporary file with a certain content
     */
   def createTmpFile(content: String, prefix: String = "config", suffix: String = ".conf"): Path = {
-    val tmpFile = File.newTemporaryFile(prefix, suffix)
-    tmpFile.write(content)(Seq(StandardOpenOption.CREATE), StandardCharsets.UTF_8)
-    tmpFile.path
+    val tmpFile = Files.createTempFile(prefix, suffix)
+    Files.write(tmpFile, content.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE)
+    tmpFile
   }
 
   /**
@@ -34,10 +34,17 @@ object FileHelper {
     * @return config file path closer to the root
     */
   def findConfigurationFile(root: Path, configFileNames: Set[String], maxDepth: Int = 5): Option[Path] = {
-    File(root)
-      .walk(maxDepth = maxDepth)
-      .find(file => configFileNames.contains(file.name))
-      .map(_.path)
+    Files
+      .walk(root, maxDepth)
+      .iterator()
+      .asScala
+      .find { file =>
+        val fileName = Option(file.getFileName) match {
+          case Some(path) => path.toString
+          case None => ""
+        }
+        configFileNames.contains(fileName)
+      }
   }
 
 }

--- a/src/test/scala/com/codacy/tools/scala/seed/DockerEngineSpecs.scala
+++ b/src/test/scala/com/codacy/tools/scala/seed/DockerEngineSpecs.scala
@@ -1,8 +1,7 @@
 package com.codacy.tools.scala.seed
 
-import java.io.{ByteArrayOutputStream, PrintStream}
+import java.io.{ByteArrayOutputStream, File, PrintStream}
 
-import better.files.File
 import com.codacy.plugins.api.results.Result.FileError
 import com.codacy.plugins.api.results.{Pattern, Tool}
 import com.codacy.plugins.api.{ErrorMessage, Options, Source}


### PR DESCRIPTION
I want to start using Scala Native instead of Graalvm native-image. `better-files` is not being maintained a lot these days. Since we do little use of it in this library I ported the existing code to use java.io and java.nio directly, so we have less dependencies and the tools are easier to port to Scala Native